### PR TITLE
Add more control over when to use different memory spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,20 @@ The runtime options change the properties of the grid and its decomposition, as 
           -   __raja_cuda__ RAJA cuda GPU execution pattern
           -   __mpi_type__ MPI datatypes MPI implementation execution pattern
   -   __\-memory *option*__ Memory space options
-      -   __enable|disable *option*__ Enable or disable specific memory spaces for mesh allocations
+      -   __UseType *enable|disable*__ Optional UseType modifier for enable|disable, default is all. UseType specifies what uses to enable|disable, for example "-memory buffer disable cuda_pinned" disables cuda_pinned buffer allocations.
+          -   __all__ all use types
+          -   __mesh__ mesh use type
+          -   __buffer__ cuda pinned memory space
+      -   __enable|disable *option*__ Enable or disable specific memory spaces for UseType allocations
           -   __all__ all memory spaces
           -   __host__ host CPU memory space
           -   __cuda_pinned__ cuda pinned memory space
           -   __cuda_device__ cuda device memory space
           -   __cuda_managed__ cuda managed memory space
           -   __cuda_managed_host_preferred__ cuda managed with host preferred advice memory space
-          -   __cuda_managed_host_preferred_device_accessed__ cuda managed with host preferred and device accessed advice memory space
+          -   __cuda_managed_host_preferred_device_accessed__ cuda managed with host preferred and device accessed    advice memory space
           -   __cuda_managed_device_preferred__ cuda managed with device preferred advice memory space
-          -   __cuda_managed_device_preferred_host_accessed__ cuda managed with device preferred and host accessed advice memory space
+          -   __cuda_managed_device_preferred_host_accessed__ cuda managed with device preferred and host accessed    advice memory space
   -   __\-cuda_aware_mpi__ Assert that you are using a cuda aware mpi implementation and enable tests that pass cuda device or managed memory to MPI
   -   __\-cuda_host_accessible_from_device__ Assert that your system supports pageable host memory access from the device and enable tests that access pageable host memory on the device
   -   __\-use_device_preferred_for_cuda_util_aloc__ Use device preferred host accessed memory for cuda utility allocations instead of host pinned memory, mainly affects fused kernels

--- a/include/do_cycles.hpp
+++ b/include/do_cycles.hpp
@@ -30,7 +30,9 @@ bool should_do_cycles(CommContext<pol_comm>& con_comm_in,
                       ContextHolder<exec_few>& con_few_in,   AllocatorInfo& aloc_few_in)
 {
   return con_mesh_in.available() && con_many_in.available() && con_few_in.available()
-      && aloc_mesh_in.available() // && aloc_many_in.available() && aloc_few_in.available()
+      && aloc_mesh_in.available(AllocatorInfo::UseType::Mesh)
+      && aloc_many_in.available(AllocatorInfo::UseType::Buffer)
+      && aloc_few_in.available(AllocatorInfo::UseType::Buffer)
       && aloc_many_in.accessible(con_comm_in) && aloc_few_in.accessible(con_comm_in)
       && aloc_mesh_in.accessible(con_mesh_in.get())
       && aloc_mesh_in.accessible(con_many_in.get()) && aloc_many_in.accessible(con_many_in.get())

--- a/src/comb.cpp
+++ b/src/comb.cpp
@@ -151,7 +151,12 @@ int main(int argc, char** argv)
 
   // stores whether each exec policy is available for use
   COMB::Executors exec;
+
+  // set default executor availability
   exec.seq.m_available = true;
+#ifdef COMB_ENABLE_CUDA
+  exec.cuda.m_available = true;
+#endif
 
   // set default allocator availability
   alloc.host.set_available({{COMB::AllocatorInfo::UseType::Mesh}}, true);

--- a/src/test_copy.cpp
+++ b/src/test_copy.cpp
@@ -24,7 +24,10 @@ bool should_do_copy(ContextHolder<exec_type>& con_in,
                     COMB::AllocatorInfo& src_aloc_in)
 {
   return con_in.available()
-      && dst_aloc_in.available() // && src_aloc_in.available()
+      && (dst_aloc_in.available(COMB::AllocatorInfo::UseType::Mesh)
+       || dst_aloc_in.available(COMB::AllocatorInfo::UseType::Buffer))
+      && (src_aloc_in.available(COMB::AllocatorInfo::UseType::Mesh)
+       || src_aloc_in.available(COMB::AllocatorInfo::UseType::Buffer))
       && dst_aloc_in.accessible(con_in.get())
       && src_aloc_in.accessible(con_in.get()) ;
 }

--- a/src/warmup.cpp
+++ b/src/warmup.cpp
@@ -57,26 +57,65 @@ void warmup(COMB::Executors& exec,
 #endif
 
 #ifdef COMB_ENABLE_CUDA
-  do_warmup(exec.seq.get(), alloc.cuda_hostpinned.allocator(), tm, num_vars, len);
+  // find an available cuda allocator for use later
+  COMB::AllocatorInfo* cuda_alloc = nullptr;
 
-  do_warmup(exec.cuda.get(), alloc.cuda_device.allocator(), tm, num_vars, len);
-
-  do_warmup(exec.seq.get(),  alloc.cuda_managed.allocator(), tm, num_vars, len);
-  do_warmup(exec.cuda.get(), alloc.cuda_managed.allocator(), tm, num_vars, len);
-
-  if (alloc.cuda_managed_host_preferred.available()) {
-    do_warmup(exec.seq.get(),  alloc.cuda_managed_host_preferred.allocator(),   tm, num_vars, len);
-    do_warmup(exec.cuda.get(), alloc.cuda_managed_device_preferred.allocator(), tm, num_vars, len);
+  if (alloc.cuda_device.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_device.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.cuda.get(), alloc.cuda_device.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_device; }
   }
 
-  if (alloc.cuda_managed_host_preferred_device_accessed.available()) {
+  if (alloc.cuda_hostpinned.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_hostpinned.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.seq.get(), alloc.cuda_hostpinned.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_hostpinned; }
+  }
+
+  if (alloc.cuda_managed.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_managed.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.seq.get(),  alloc.cuda_managed.allocator(), tm, num_vars, len);
+    do_warmup(exec.cuda.get(), alloc.cuda_managed.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_managed; }
+  }
+
+  if (alloc.cuda_managed_host_preferred.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_managed_host_preferred.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.seq.get(),  alloc.cuda_managed_host_preferred.allocator(),   tm, num_vars, len);
+    do_warmup(exec.cuda.get(), alloc.cuda_managed_host_preferred.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_managed_host_preferred; }
+  }
+
+  if (alloc.cuda_managed_device_preferred.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_managed_device_preferred.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.seq.get(),  alloc.cuda_managed_device_preferred.allocator(),   tm, num_vars, len);
+    do_warmup(exec.cuda.get(), alloc.cuda_managed_device_preferred.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_managed_device_preferred; }
+  }
+
+  if (alloc.cuda_managed_host_preferred_device_accessed.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_managed_host_preferred_device_accessed.available(COMB::AllocatorInfo::UseType::Buffer)) {
     do_warmup(exec.seq.get(),  alloc.cuda_managed_host_preferred_device_accessed.allocator(), tm, num_vars, len);
+    do_warmup(exec.cuda.get(), alloc.cuda_managed_host_preferred_device_accessed.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_managed_host_preferred_device_accessed; }
+  }
+
+  if (alloc.cuda_managed_device_preferred_host_accessed.available(COMB::AllocatorInfo::UseType::Mesh)
+   || alloc.cuda_managed_device_preferred_host_accessed.available(COMB::AllocatorInfo::UseType::Buffer)) {
+    do_warmup(exec.seq.get(),  alloc.cuda_managed_device_preferred_host_accessed.allocator(), tm, num_vars, len);
     do_warmup(exec.cuda.get(), alloc.cuda_managed_device_preferred_host_accessed.allocator(), tm, num_vars, len);
+    if (!cuda_alloc) { cuda_alloc = &alloc.cuda_managed_device_preferred_host_accessed; }
+  }
+
+  if (alloc.host.accessible(exec.seq.get())) {
+    if (!cuda_alloc) { cuda_alloc = &alloc.host; }
   }
 #endif
 
 #ifdef COMB_ENABLE_CUDA_GRAPH
-  do_warmup(exec.cuda_graph.get(), alloc.cuda_device.allocator(), tm, num_vars, len);
+  if (cuda_alloc) {
+    do_warmup(exec.cuda_graph.get(), cuda_alloc->allocator(), tm, num_vars, len);
+  }
 #endif
 
 #ifdef COMB_ENABLE_RAJA
@@ -87,7 +126,9 @@ void warmup(COMB::Executors& exec,
 #endif
 
 #ifdef COMB_ENABLE_CUDA
-  do_warmup(exec.raja_cuda.get(), alloc.cuda_device.allocator(), tm, num_vars, len);
+  if (cuda_alloc) {
+    do_warmup(exec.raja_cuda.get(), cuda_alloc->allocator(), tm, num_vars, len);
+  }
 #endif
 #endif
 }


### PR DESCRIPTION
Add an optional modifier to the -memory option to allow specific uses of the memory to be enabled or disabled, the default is all. The available use types are mesh, buffer, and all.
This allows memory spaces to be enabled or disabled or disabled at a finer granularity allowing users to hone in on specific tests.
This does change the default memory spaces that are used for buffers and some memory spaces have been enabled for use as buffers by default to get close to the previous default behavior.

Enable only host memory for mesh and buffers:
`./comb 10_10_10 -divide 1_1_1 -memory disable all -memory enable host`

Enable all memory for mesh and only cuda_device for buffers:
`./comb 10_10_10 -divide 1_1_1 -memory mesh enable all -memory buffer disable all -memory buffer enable cuda_device`
 