### PR TITLE
Fix adiak target in SetupPackages.cmake

### DIFF
--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -230,6 +230,6 @@ if (COMB_ENABLE_ADIAK)
   # register Adiak with blt
   blt_register_library(NAME Adiak
                        INCLUDES ${adiak_INCLUDE_DIRS}
-                       LIBRARIES adiak
+                       LIBRARIES ${adiak_LIBRARIES}
                        DEFINES USE_ADIAK)
 endif()


### PR DESCRIPTION
We changed the adiak CMake target in newer adiak versions. The adiak_LIBRARIES variable works for both old and new versions.