### PR TITLE
Don't quit if MPI thread support is higher than requested

### DIFF
--- a/src/comb.cpp
+++ b/src/comb.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
   CommInfo comminfo;
 
 #ifdef COMB_ENABLE_MPI
-  if (required != provided) {
+  if (required > provided) {
     fgprintf(FileGroup::err_master, "Didn't receive MPI thread support required %i provided %i.\n", required, provided);
     comminfo.abort();
   }


### PR DESCRIPTION
MPI can return a higher thread support level than requested. This shouldn't abort the program. I'm running into this on the EAS3 machines.